### PR TITLE
Update opam

### DIFF
--- a/opam
+++ b/opam
@@ -14,5 +14,5 @@ install: [make "install"]
 remove: [make "uninstall"]
 depends: [
   "ocamlfind" {build}
-  "uri"
+  "uri" {>= "1.9.0" }
 ]


### PR DESCRIPTION
Add version constraint for `uri`. This is required for `Uri.canonicalize`  introduced only in uri.1.9.0: https://github.com/mirage/ocaml-uri/commit/c96f401a05f4d92a4b096179c8a23a9949994bcb